### PR TITLE
Fix duplicated env_namespace in get_client method

### DIFF
--- a/lib/nfe-paulistana/gateway.rb
+++ b/lib/nfe-paulistana/gateway.rb
@@ -89,7 +89,6 @@ module NfePaulistana
                    ssl_cert_key_file: @options[:ssl_key_path], 
                    ssl_cert_key_password: @options[:ssl_cert_pass], 
                    wsdl: @options[:wsdl], 
-                   env_namespace: :soap, 
                    namespace_identifier: nil)
     end
   end


### PR DESCRIPTION
Fixes warning caused by duplicated env_namespace: :soap in get_client method

```
warning: duplicated key at line 92 ignored: :env_namespace
```