### PR TITLE
Fix old and strict dependencies versions

### DIFF
--- a/nfe-paulistana.gemspec
+++ b/nfe-paulistana.gemspec
@@ -18,12 +18,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  # specify any dependencies here; for example:
   s.add_dependency "nokogiri", ">= 1.5.9"
   s.add_dependency "savon", "~> 2.3"
   s.add_dependency "signer"
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest"
   s.add_development_dependency "debugger"
-  # s.add_runtime_dependency "rest-client"
 end

--- a/nfe-paulistana.gemspec
+++ b/nfe-paulistana.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   # specify any dependencies here; for example:
-  s.add_dependency "nokogiri", "1.5.9"
-  s.add_dependency "savon", "2.3.0"
+  s.add_dependency "nokogiri", ">= 1.5.9"
+  s.add_dependency "savon", "~> 2.3"
   s.add_dependency "signer"
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest"


### PR DESCRIPTION
Dependencies versions are pinned to 2013 releases.
The gem works well using the most recent version of savon (2.11.1) and nokogiri (1.6.8)