### PR TITLE
Update savon and remove debugger dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,56 +2,61 @@ PATH
   remote: .
   specs:
     nfe-paulistana (1.0.3)
-      nokogiri (= 1.5.9)
-      savon (= 2.3.0)
+      nokogiri (>= 1.5.9)
+      savon (~> 2.11)
       signer
 
 GEM
   remote: http://rubygems.org/
   specs:
-    akami (1.2.2)
+    akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
-    builder (3.2.2)
-    columnize (0.8.9)
-    debugger (1.6.8)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.5)
-    gyoku (1.1.1)
+    builder (3.2.3)
+    coderay (1.1.2)
+    gyoku (1.3.1)
       builder (>= 2.1.2)
-    httpi (2.1.1)
+    httpi (2.4.3)
       rack
-      rubyntlm (~> 0.3.2)
-    mime-types (1.25.1)
+      socksify
+    method_source (0.8.2)
+    mini_portile2 (2.3.0)
     minitest (5.4.0)
-    nokogiri (1.5.9)
-    nori (2.3.0)
-    rack (1.6.4)
+    nokogiri (1.8.2)
+      mini_portile2 (~> 2.3.0)
+    nori (2.6.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-nav (0.2.4)
+      pry (>= 0.9.10, < 0.11.0)
+    rack (2.0.4)
     rake (10.3.2)
-    rubyntlm (0.3.4)
-    savon (2.3.0)
-      akami (~> 1.2.0)
+    savon (2.12.0)
+      akami (~> 1.2)
       builder (>= 2.1.2)
-      gyoku (~> 1.1.0)
-      httpi (~> 2.1.0)
-      nokogiri (>= 1.4.0, < 1.6)
-      nori (~> 2.3.0)
-      wasabi (~> 3.2.0)
-    signer (1.4.2)
+      gyoku (~> 1.2)
+      httpi (~> 2.3)
+      nokogiri (>= 1.8.1)
+      nori (~> 2.4)
+      wasabi (~> 3.4)
+    signer (1.6.0)
       nokogiri (>= 1.5.1)
-    wasabi (3.2.3)
+    slop (3.6.0)
+    socksify (1.7.1)
+    wasabi (3.5.0)
       httpi (~> 2.0)
-      mime-types (< 2.0.0)
-      nokogiri (>= 1.4.0)
+      nokogiri (>= 1.4.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  debugger
   minitest
   nfe-paulistana!
+  pry-nav
   rake
+
+BUNDLED WITH
+   1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    nfe-paulistana (1.0.3)
-      nokogiri (>= 1.5.9)
+    nfe-paulistana (1.0.4)
+      nokogiri (>= 1.6)
       savon (~> 2.11)
       signer
 

--- a/lib/nfe-paulistana/version.rb
+++ b/lib/nfe-paulistana/version.rb
@@ -1,3 +1,3 @@
 module NfePaulistana
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end

--- a/nfe-paulistana.gemspec
+++ b/nfe-paulistana.gemspec
@@ -19,9 +19,10 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "nokogiri", ">= 1.5.9"
-  s.add_dependency "savon", "~> 2.3"
+  s.add_dependency "savon", "~> 2.11"
   s.add_dependency "signer"
+
   s.add_development_dependency "rake"
   s.add_development_dependency "minitest"
-  s.add_development_dependency "debugger"
+  s.add_development_dependency "pry-nav"
 end

--- a/nfe-paulistana.gemspec
+++ b/nfe-paulistana.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "nokogiri", ">= 1.5.9"
+  s.add_dependency "nokogiri", ">= 1.6"
   s.add_dependency "savon", "~> 2.11"
   s.add_dependency "signer"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,4 @@
 require 'minitest'
 require 'minitest/autorun'
 require 'minitest/pride'
-require 'debugger'
 require File.expand_path('../../lib/nfe-paulistana.rb', __FILE__)


### PR DESCRIPTION
The gem debugger is outdate to Ruby 2+, I suggest update to use
[Pry](https://github.com/pry/pry) with navigation plugin `pry-nav`.
Also bump version of Savon to 2.11.

This PR:

- Fix #12
- Fix #14